### PR TITLE
1.1.1

### DIFF
--- a/data/rules.js
+++ b/data/rules.js
@@ -2,20 +2,17 @@ const $kurlc_rules = [
     {
         name: 'Global',
         match: /.*/,
-        rules: ['ga_source', 'ga_medium', 'ga_term', 'ga_content', 'ga_campaign', 'ga_place', 'utm_campaign', 'utm_source', 'utm_medium', 'utm_content', 'utm_term', 'gclid', 'gclsrc'],
-        replace: []
+        rules: ['ga_source', 'ga_medium', 'ga_term', 'ga_content', 'ga_campaign', 'ga_place', 'utm_campaign', 'utm_source', 'utm_medium', 'utm_content', 'utm_term', 'gclid', 'gclsrc']
     },
     {
         name: 'audible.com',
         match: /www.audible.com/i,
-        rules: ['qid', 'sr', 'pf_rd_p', 'pf_rd_r', 'plink', 'ref'],
-        replace: []
+        rules: ['qid', 'sr', 'pf_rd_p', 'pf_rd_r', 'plink', 'ref']
     },
     {
         name: 'bandcamp.com',
         match: /.*.bandcamp.com/gi,
-        rules: ['from', 'search_item_id', 'search_item_type', 'search_match_part', 'search_page_id', 'search_page_no', 'search_rank', 'search_sig'],
-        replace: []
+        rules: ['from', 'search_item_id', 'search_item_type', 'search_match_part', 'search_page_id', 'search_page_no', 'search_rank', 'search_sig']
     },
     {
         name: 'amazon.com',
@@ -26,182 +23,152 @@ const $kurlc_rules = [
     {
         name: 'reddit.com',
         match: /.*.reddit.com/i,
-        rules: ['ref_campaign', 'ref_source'],
-        replace: []
+        rules: ['ref_campaign', 'ref_source']
     },
     {
         name: 'twitch.tv',
         match: /www.twitch.tv/i,
-        rules: ['tt_medium', 'tt_content', 'tt_email_id'],
-        replace: []
+        rules: ['tt_medium', 'tt_content', 'tt_email_id']
     },
     {
         name: 'blog.twitch.tv',
         match: /blog.twitch.tv/i,
-        rules: ['utm_referrer'],
-        replace: []
+        rules: ['utm_referrer']
     },
     {
         name: 'pixiv.net',
         match: /www.pixiv.net/i,
-        rules: ['p', 'i', 'g'],
-        replace: []
+        rules: ['p', 'i', 'g']
     },
     {
         name: 'spotify.com',
         match: /open.spotify.com/i,
-        rules: ['si', 'utm_source', 'context'],
-        replace: []
+        rules: ['si', 'utm_source', 'context']
     },
     {
         name: 'aliexpress.com',
         match: /.*.aliexpress.com/i,
-        rules: ['_t', 'spm', 'algo_pvid', 'algo_expid', 'btsid', 'ws_ab_test', 'initiative_id', 'origin', 'widgetId', 'tabType', 'productId', 'productIds', 'gps-id', 'scm', 'scm_id', 'scm-url', 'pvid'],
-        replace: []
+        rules: ['_t', 'spm', 'algo_pvid', 'algo_expid', 'btsid', 'ws_ab_test', 'initiative_id', 'origin', 'widgetId', 'tabType', 'productId', 'productIds', 'gps-id', 'scm', 'scm_id', 'scm-url', 'pvid']
     },
     {
         name: 'google.com',
         match: /www.google\..*/i,
-        rules: ['sourceid', 'client', 'aqs', 'sxsrf', 'uact', 'ved', 'iflsig', 'source', 'ei', 'oq', 'gs_lcp', 'sclient', 'bih', 'biw', 'sa', 'dpr'],
-        replace: []
+        rules: ['sourceid', 'client', 'aqs', 'sxsrf', 'uact', 'ved', 'iflsig', 'source', 'ei', 'oq', 'gs_lcp', 'sclient', 'bih', 'biw', 'sa', 'dpr']
     },
     {
         name: 'youtube.com',
         match: /.*.youtube.com/i,
-        rules: ['gclid'],
-        replace: []
+        rules: ['gclid']
     },
     {
         name: 'humblebundle.com',
         match: /www.humblebundle.com/i,
-        rules: ['hmb_source', 'hmb_medium', 'hmb_campaign', 'mcID', 'linkID'],
-        replace: []
+        rules: ['hmb_source', 'hmb_medium', 'hmb_campaign', 'mcID', 'linkID']
     },
     {
         name: 'greenmangaming.com',
         match: /www.greenmangaming.com/i,
-        rules: ['CJEVENT', 'cjevent'],
-        replace: []
+        rules: ['CJEVENT', 'cjevent']
     },
     {
         name: 'fanatical.com',
         match: /www.fanatical.com/i,
-        rules: ['cj_pid', 'cj_aid', 'aff_track', 'CJEVENT', 'cjevent'],
-        replace: []
+        rules: ['cj_pid', 'cj_aid', 'aff_track', 'CJEVENT', 'cjevent']
     },
     {
         name: 'gamebillet.com',
         match: /www.gamebillet.com/i,
-        rules: ['affiliate'],
-        replace: []
+        rules: ['affiliate']
     },
     {
         name: 'newsweek.com',
         match: /www.newsweek.com/i,
-        rules: ['subref'],
-        replace: []
+        rules: ['subref']
     },
     {
         name: 'imgur.com',
         match: /imgur.com/i,
-        rules: ['source'],
-        replace: []
+        rules: ['source']
     },
     {
         name: 'plex.tv',
         match: /.*.plex.tv/i,
-        rules: ['origin', 'plex_utm', 'sl', 'ckhid'],
-        replace: []
+        rules: ['origin', 'plex_utm', 'sl', 'ckhid']
     },
     {
         name: 'imdb.com',
         match: /www.imdb.com/i,
-        rules: ['ref_', 'pf_rd_m', 'pf_rd_r', 'pf_rd_p', 'pf_rd_s', 'pf_rd_t', 'pf_rd_i'],
-        replace: []
+        rules: ['ref_', 'pf_rd_m', 'pf_rd_r', 'pf_rd_p', 'pf_rd_s', 'pf_rd_t', 'pf_rd_i']
     },
     {
         name: 'gog.com',
         match: /www.gog.com/i,
-        rules: ['at_gd'],
-        replace: []
+        rules: ['at_gd']
     },
     {
         name: 'tiktok.com',
         match: /www.tiktok.com/i,
-        rules: ['is_copy_url', 'is_from_webapp', 'sender_device', 'sender_web_id'],
-        replace: []
+        rules: ['is_copy_url', 'is_from_webapp', 'sender_device', 'sender_web_id']
     },
     {
         name: 'facebook.com',
         match: /www.facebook.com/i,
-        rules: ['fbclid', 'fb_ref', 'fb_source'],
-        replace: []
+        rules: ['fbclid', 'fb_ref', 'fb_source']
     },
     {
         name: 'yandex.com',
         match: /yandex.com/i,
-        rules: ['lr', 'from', 'grhow', 'origin', '_openstat'],
-        replace: []
+        rules: ['lr', 'from', 'grhow', 'origin', '_openstat']
     },
     {
         name: 'store.steampowered.com',
         match: /store.steampowered.com/i,
-        rules: ['snr'],
-        replace: []
+        rules: ['snr']
     },
     {
         name: 'findojobs.co.nz',
         match: /www.findojobs.co.nz/i,
-        rules: ['source'],
-        replace: []
+        rules: ['source']
     },
     {
         name: 'linkedin.com',
         match: /.*.linkedin.com/i,
-        rules: ['contextUrn', 'destRedirectURL', 'lipi', 'licu', 'trk', 'trkInfo', 'originalReferer', 'upsellOrderOrigin', 'upsellTrk', 'upsellTrackingId', 'src'],
-        replace: []
+        rules: ['contextUrn', 'destRedirectURL', 'lipi', 'licu', 'trk', 'trkInfo', 'originalReferer', 'upsellOrderOrigin', 'upsellTrk', 'upsellTrackingId', 'src']
     },
     {
         name: 'indeed.com',
         match: /.*.indeed.com/i,
-        rules: ['from', 'attributionid'],
-        replace: []
+        rules: ['from', 'attributionid']
     },
     {
         name: 'discord.com',
         match: /.*.discord.com/i,
-        rules: ['source'],
-        replace: []
+        rules: ['source']
     },
     {
         name: 'medium.com',
         match: /medium.com/i,
-        rules: ['source'],
-        replace: []
+        rules: ['source']
     },
     {
         name: 'twitter.com',
         match: /twitter.com/i,
-        rules: ['s', 'src', 'ref_url', 'ref_src'],
-        replace: []
+        rules: ['s', 'src', 'ref_url', 'ref_src']
     },
     {
         name: 'voidu.com',
         match: /voidu.com/i,
-        rules: ['affiliate'],
-        replace: []
+        rules: ['affiliate']
     },
     {
         name: 'wingamestore.com',
         match: /wingamestore.com/i,
-        rules: ['ars'],
-        replace: []
+        rules: ['ars']
     },
     {
         name: 'gamebillet.com',
         match: /gamebillet.com/i,
-        rules: ['affiliate'],
-        replace: []
+        rules: ['affiliate']
     },
     {
         name: 'gamesload.com',
@@ -212,40 +179,32 @@ const $kurlc_rules = [
     {
         name: 'mightyape',
         match: /mightyape.co.(nz|au)/i,
-        rules: ['m'],
-        replace: []
+        rules: ['m']
     },
     {
         name: 'music.apple.com',
         match: /music.apple.com/i,
-        rules: ['uo', 'app', 'at', 'ct', 'ls'],
-        replace: []
+        rules: ['uo', 'app', 'at', 'ct', 'ls']
     },
     {
         name: 'play.google.com',
         match: /play.google.com/i,
-        rules: ['referrer'],
-        replace: []
+        rules: ['referrer']
     },
     {
         name: 'adtraction.com',
         match: /adtraction.com/i,
-        rules: [],
-        replace: [],
-        custom: (url) => {
-            const target = new URL(url).searchParams;
-            return target.has('url') ? target.get('url') : url;
-        }
+        redirect: 'url'
     },
     {
         name: 'dpbolvw.net',
         match: /dpbolvw.net/i,
-        rules: [],
-        replace: [],
-        custom: (url) => {
-            const target = new URL(url).searchParams;
-            return target.has('URL') ? target.get('URL') : url;
-        }
+        redirect: 'URL'
+    },
+    {
+        name: 'itch.io',
+        match: /itch.io/i,
+        rules: ['fbclid']
     }
 ];
 

--- a/data/supported-sites.txt
+++ b/data/supported-sites.txt
@@ -1,14 +1,15 @@
-Total unique rules: 155
+Total unique rules: 158
 
 | Match                  | Rules |
 | :--------------------- | :---- |
-| adtraction.com         | 0     |
+| adtraction.com         | 1     |
 | aliexpress.com         | 17    |
 | amazon.com             | 24    |
 | audible.com            | 6     |
 | bandcamp.com           | 8     |
 | blog.twitch.tv         | 1     |
 | discord.com            | 1     |
+| dpbolvw.net            | 1     |
 | facebook.com           | 3     |
 | fanatical.com          | 5     |
 | findojobs.co.nz        | 1     |
@@ -22,6 +23,7 @@ Total unique rules: 155
 | imdb.com               | 7     |
 | imgur.com              | 1     |
 | indeed.com             | 2     |
+| itch.io                | 1     |
 | linkedin.com           | 11    |
 | medium.com             | 1     |
 | mightyape              | 1     |

--- a/data/tidy.user.js
+++ b/data/tidy.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Tidy URL
 // @namespace    https://ksir.pw
-// @version      1.1.0
+// @version      1.1.1
 // @description  Cleans/removes garbage or tracking parameters from URLs
 // @author       Kain (ksir.pw)
 // @include      *
@@ -21,13 +21,21 @@ var TidyCleaner = /** @class */ (function () {
         this.silent = false;
         // Load the rules
         try {
-            if (typeof $kurlc_rules === 'udefined') console.error('[TidyURL] Failed to load rules.js - Script will not work');
-            else this.rules = $kurlc_rules;
+            this.rules = require('../data/rules.js');
         } catch (error) {
             this.log('' + error);
             this.rules = [];
         }
     }
+    Object.defineProperty(TidyCleaner.prototype, 'expandedRules', {
+        get: function () {
+            return this.rules.map(function (rule) {
+                return Object.assign({ rules: [], replace: [], redirect: '' }, rule);
+            });
+        },
+        enumerable: false,
+        configurable: true
+    });
     /**
      * Only log to the console if debug is enabled
      * @param str Message
@@ -62,22 +70,19 @@ var TidyCleaner = /** @class */ (function () {
                 replace: [],
                 remove: [],
                 match: [],
-                custom: false
+                redirect: ''
             }
         };
-
         // Make sure the URL is valid before we try to clean it
         if (!this.validate(url)) {
             this.log('An invalid URL was supplied');
             return data;
         }
-
         var original = new URL(url);
         var cleaner = original.searchParams;
         var pathname = original.pathname;
-
         // Loop through the rules and match them to the host name
-        for (var _i = 0, _a = this.rules; _i < _a.length; _i++) {
+        for (var _i = 0, _a = this.expandedRules; _i < _a.length; _i++) {
             var rule = _a[_i];
             if (rule.match.exec(original.host) !== null) {
                 data.info.remove = [...data.info.remove, ...rule.rules];
@@ -85,30 +90,25 @@ var TidyCleaner = /** @class */ (function () {
                 data.info.match.push(rule);
             }
         }
-
         // Delete any matching parameters
         for (var _b = 0, _c = data.info.remove; _b < _c.length; _b++) {
             var key = _c[_b];
             if (cleaner.has(key)) cleaner.delete(key);
         }
-
         // Update the pathname if needed
         for (var _d = 0, _e = data.info.replace; _d < _e.length; _d++) {
-            var keyB = _e[_d];
-            var changed = pathname.replace(keyB, '');
+            var key = _e[_d];
+            var changed = pathname.replace(key, '');
             if (changed !== pathname) pathname = changed;
         }
-
         // Rebuild URL
         var params = cleaner.toString().length ? '?' + cleaner.toString() : '';
         data.url = original.origin + pathname + params;
-
-        // Run custom function if needed (special case)
+        // Redirect if needed
         for (var _f = 0, _g = data.info.match; _f < _g.length; _f++) {
-            var ruleB = _g[_f];
-            if (rule.custom) {
-                data.url = ruleB.custom(data.url);
-                data.info.custom = true;
+            var rule = _g[_f];
+            if (rule.redirect.length && cleaner.has(rule.redirect)) {
+                data.url = '' + cleaner.get(rule.redirect);
             }
         }
         data.info.reduction = +(100 - (data.url.length / url.length) * 100).toFixed(2);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,6 +2,7 @@ import { IRule, IData } from './interface';
 declare class TidyCleaner {
     rules: IRule[];
     silent: boolean;
+    get expandedRules(): IRule[];
     constructor();
     /**
      * Only log to the console if debug is enabled

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,6 +19,15 @@ var TidyCleaner = /** @class */ (function () {
             this.rules = [];
         }
     }
+    Object.defineProperty(TidyCleaner.prototype, "expandedRules", {
+        get: function () {
+            return this.rules.map(function (rule) {
+                return Object.assign({ rules: [], replace: [], redirect: '' }, rule);
+            });
+        },
+        enumerable: false,
+        configurable: true
+    });
     /**
      * Only log to the console if debug is enabled
      * @param str Message
@@ -55,7 +64,7 @@ var TidyCleaner = /** @class */ (function () {
                 replace: [],
                 remove: [],
                 match: [],
-                custom: false
+                redirect: ''
             }
         };
         // Make sure the URL is valid before we try to clean it
@@ -67,7 +76,7 @@ var TidyCleaner = /** @class */ (function () {
         var cleaner = original.searchParams;
         var pathname = original.pathname;
         // Loop through the rules and match them to the host name
-        for (var _i = 0, _a = this.rules; _i < _a.length; _i++) {
+        for (var _i = 0, _a = this.expandedRules; _i < _a.length; _i++) {
             var rule = _a[_i];
             if (rule.match.exec(original.host) !== null) {
                 data.info.remove = __spreadArray(__spreadArray([], data.info.remove), rule.rules);
@@ -91,12 +100,11 @@ var TidyCleaner = /** @class */ (function () {
         // Rebuild URL
         var params = cleaner.toString().length ? '?' + cleaner.toString() : '';
         data.url = original.origin + pathname + params;
-        // Run custom function if needed (special case)
+        // Redirect if needed
         for (var _f = 0, _g = data.info.match; _f < _g.length; _f++) {
             var rule = _g[_f];
-            if (rule.custom) {
-                data.url = rule.custom(data.url);
-                data.info.custom = true;
+            if (rule.redirect.length && cleaner.has(rule.redirect)) {
+                data.url = "" + cleaner.get(rule.redirect);
             }
         }
         data.info.reduction = +(100 - (data.url.length / url.length) * 100).toFixed(2);

--- a/lib/interface.d.ts
+++ b/lib/interface.d.ts
@@ -3,7 +3,7 @@ export interface IRule {
     match: RegExp;
     rules: string[];
     replace: any[];
-    custom?: (url: string) => string;
+    redirect: string;
 }
 export interface IData {
     /** Cleaned URL */
@@ -19,7 +19,7 @@ export interface IData {
         remove: any[];
         /** Rules matched */
         match: any[];
-        /** If custom function was run */
-        custom: boolean;
+        /** If a query parameter exists, redirect to the value */
+        redirect: string;
     };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tidy-url",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Cleans/removes tracking or garbage parameters from URLs",
     "main": "lib/index.js",
     "types": "lib/index.d.ts",

--- a/scripts/postbuild.js
+++ b/scripts/postbuild.js
@@ -29,23 +29,22 @@ const generateSupported = () => {
         let lines = rules
             .filter((rule) => rule.name !== 'Global')
             .sort((a, b) => a.name.localeCompare(b.name))
-            .map(rule => {
+            .map((rule) => {
                 if (rule.name.length > p) p = rule.name.length;
                 return rule;
             });
 
         // Create table header
-        body += [
-            '| Match'.padEnd(p + 2, ' ') + ' | Rules |',
-            '| :'.padEnd(p + 2, '-') + ' | :---- |'
-        ].join('\n') + '\n'
+        body += ['| Match'.padEnd(p + 2, ' ') + ' | Rules |', '| :'.padEnd(p + 2, '-') + ' | :---- |'].join('\n') + '\n';
 
         // Append rules to table
-        body += lines.map((rule) => {
-            const n = rule.rules.length;
-            count += n;
-            return `| ${rule.name.padEnd(p, ' ')} | ${`${n}`.padEnd(5, ' ')} |`;
-        }).join('\n');
+        body += lines
+            .map((rule) => {
+                const n = rule.rules ? rule.rules.length : 1;
+                count += n;
+                return `| ${rule.name.padEnd(p, ' ')} | ${`${n}`.padEnd(5, ' ')} |`;
+            })
+            .join('\n');
 
         // Update the rule count
         body = body.replace('%RULE_COUNT%', count);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,12 @@ class TidyCleaner {
     public rules: IRule[] = [];
     public silent = false;
 
+    get expandedRules() {
+        return this.rules.map((rule) => {
+            return Object.assign({ rules: [], replace: [], redirect: '' }, rule) as IRule;
+        });
+    }
+
     constructor() {
         // Load the rules
         try {
@@ -50,7 +56,7 @@ class TidyCleaner {
                 replace: [],
                 remove: [],
                 match: [],
-                custom: false
+                redirect: ''
             }
         };
 
@@ -65,7 +71,7 @@ class TidyCleaner {
         let pathname = original.pathname;
 
         // Loop through the rules and match them to the host name
-        for (let rule of this.rules) {
+        for (let rule of this.expandedRules) {
             if (rule.match.exec(original.host) !== null) {
                 data.info.remove = [...data.info.remove, ...rule.rules];
                 data.info.replace = [...data.info.replace, ...rule.replace];
@@ -88,11 +94,10 @@ class TidyCleaner {
         const params = cleaner.toString().length ? '?' + cleaner.toString() : '';
         data.url = original.origin + pathname + params;
 
-        // Run custom function if needed (special case)
+        // Redirect if needed
         for (let rule of data.info.match) {
-            if (rule.custom) {
-                data.url = rule.custom(data.url);
-                data.info.custom = true;
+            if (rule.redirect.length && cleaner.has(rule.redirect)) {
+                data.url = `${cleaner.get(rule.redirect)}`;
             }
         }
 

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -4,7 +4,7 @@ export interface IRule {
     match: RegExp;
     rules: string[];
     replace: any[];
-    custom?: (url: string) => string;
+    redirect: string;
 }
 
 export interface IData {
@@ -21,7 +21,7 @@ export interface IData {
         remove: any[];
         /** Rules matched */
         match: any[];
-        /** If custom function was run */
-        custom: boolean;
+        /** If a query parameter exists, redirect to the value */
+        redirect: string;
     };
 }

--- a/test.ts
+++ b/test.ts
@@ -28,7 +28,9 @@ const tests = [
     'https://www.amazon.com/dp/B01JA49DI6/?coliid=I1HVWIICNZWQTZ&colid=107BE3PYAUBOA&psc=1',
     // TODO: Possibly a redirect based on parameter instead?
     'https://track.adtraction.com/t/t?a=1578845458&as=1605593256&t=2&tk=1&url=http%3A%2F%2Fwww.gog.com%2Fgame%2Fcyberpunk_2077',
-    'http://www.dpbolvw.net/click-6305441-10912384?URL=https%3A%2F%2Fwww.greenmangaming.com%2Fgames%2Fbattle-brothers%2F'
+    'http://www.dpbolvw.net/click-6305441-10912384?URL=https%3A%2F%2Fwww.greenmangaming.com%2Fgames%2Fbattle-brothers%2F',
+    // Bench that for now, back to regular tests
+    'https://not-a-real.itch.io/just-a-test-link?fbclid=IwAR2mlVUJ9y8WB92ubp9088bogz6eboZaBhXKhh0n1hIveHXMyif5dQmtS1s'
 ];
 
 for (let test of tests) {


### PR DESCRIPTION
- Shorten rules.js file  
- Removed `custom` rule handler  
- Added `redirect` rule handler  

Using `redirect: 'url'` will cause the script to look for a query parameter called `url` and if it exists, return that value instead.  
This is to handle websites like adtraction or dpbolvw that track link clicks before redirecting to your requested URL, sometimes with even more tracking parameters added.  
