### PR TITLE
Fix local urls incorrectly being rebuilt

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export class TidyCleaner {
         const original = new URL(url);
         const params = original.searchParams;
         const param_str = params.toString().length ? '?' + params.toString() : '';
-        return original.origin + original.pathname + param_str + original.hash;
+        return original.protocol + '//' + original.host + original.pathname + param_str + original.hash;
     }
 
     /**
@@ -139,7 +139,7 @@ export class TidyCleaner {
 
         // Rebuild URL
         const params = cleaner.toString().length ? '?' + cleaner.toString() : '';
-        data.url = original.origin + pathname + params + original.hash;
+        data.url = original.protocol + '//' + original.host + pathname + params + original.hash;
 
         // Redirect if the redirect parameter exists
         if (this.allow_redirects) {


### PR DESCRIPTION
When calling `clean` on a url that points to a local resource, the url is rebuilt incorrectly because local resource `URL`s have a `null` origin value.

For example, if the url that we want to clean is `file:///home/test.html`, then constructing a new `URL` object will be valid, but the resulting URL object will be:
```
URL {
  href: 'file:///home/test.html',
  origin: 'null',
  protocol: 'file:',
  username: '',
  password: '',
  host: '',
  hostname: '',
  port: '',
  pathname: '/home/test.html',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
```

Since the `origin` property is `null`, the rebuilt url ends up being `null/home/test.html`. This causes the `clean` function to detect that the url is invalid and return this invalid url as part of the `IData` response.

I think it might make more sense to rebuild the url using the `protocol` and `host` to determine the beginning of the rebuilt url rather than the `origin` because `origin` can sometimes be `null`. See https://github.com/whatwg/url/issues/310

In the more common case of a url that points to a web resource, then when constructing a new `URL` object, we'll get something like this:
```
URL {
  href: 'http://example.com/',
  origin: 'http://example.com',
  protocol: 'http:',
  username: '',
  password: '',
  host: 'example.com',
  hostname: 'example.com',
  port: '',
  pathname: '/',
  search: '',
  searchParams: URLSearchParams {},
  hash: ''
}
```
Using `protocol` + `host` should still succeed and end up with the same result as `origin`.