### PR TITLE
Feature/issue 37/add mylondon news website rules

### DIFF
--- a/data/rules.js
+++ b/data/rules.js
@@ -761,6 +761,11 @@ const $kurlc_rules = [
         name: 'fiverr.com',
         match: /.*\.fiverr\.com/i,
         rules: ['source', 'context_referrer', 'referrer_gig_slug', 'ref_ctx_id', 'funnel', 'imp_id']
+    },
+    {
+        name: 'mylondon.news',
+        match: /.*\.mylondon\.news/i,
+        rules: ['int_source', 'int_medium', 'int_campaign']
     }
 ];
 

--- a/data/supported-sites.txt
+++ b/data/supported-sites.txt
@@ -1,4 +1,4 @@
-Total unique rules: 564
+Total unique rules: 567
 
 | Match                         | Rules |
 | :---------------------------- | :---- |
@@ -79,6 +79,7 @@ Total unique rules: 564
 | mouser.com                    | 1     |
 | msn.com                       | 3     |
 | music.apple.com               | 5     |
+| mylondon.news                 | 3     |
 | nbcnews.com                   | 1     |
 | newsflare.com                 | 1     |
 | newsweek.com                  | 2     |


### PR DESCRIPTION
#### Reference issues/PRs
Website: mylondon.news https://github.com/DrKain/tidy-url/issues/37

#### What does this implementation/fix? Explain your changes
I added the mylondon.news website rules adding the bad parameters.

#### Any other comments?
I tested all the URLs provided before and after this implementation using the test.ts file. The website works as expected without any additional console errors or glitches. I tested in "normal" and incognito mode.

Only a doubt related to the attached image, is it fine to have the "#amp-readmore-target"? The website works as usual, but I'm not sure about this anchor.

<img width="1498" alt="Screenshot 2023-01-31 at 09 27 43" src="https://user-images.githubusercontent.com/123890236/215714790-b72e85d6-142b-48dd-980a-88ca6bde187e.png">
