### PR TITLE
Update amazon rules

### DIFF
--- a/data/rules.js
+++ b/data/rules.js
@@ -66,6 +66,7 @@ const $kurlc_rules = [
             'pf_rd_s', 'pf_rd_t', ' pf_rd_i', 'pf_rd_m', 'pd_rd_w', 'qid', 'sr',
             'keywords', 'dchild', 'ref', 'ref_', 'rnid', 'pf_rd_r', 'pf_rd_p', 'pd_rd_r',
             'smid', 'pd_rd_wg', 'content-id', 'spLa', 'crid', 'sprefix',
+            'hvlocint', 'hvdvcmdl', 'hvptwo', 'hvpone', 'hvpos',
             'qu', 'pd_rd_i', 'nc2', 'nc1', 'trk', 'sc_icampaign', 'trkCampaign',
             'ufe', 'sc_icontent', 'sc_ichannel', 'sc_iplace', 'sc_country',
             'sc_outcome', 'sc_geo', 'sc_campaign', 'sc_channel'


### PR DESCRIPTION
Add 'hvlocint', 'hvdvcmdl', 'hvptwo', 'hvpone', 'hvpos' to amazon rules

Fix https://github.com/DrKain/tidy-url/issues/61