### PR TITLE
Add lenovo.com rules

### DIFF
--- a/data/rules.js
+++ b/data/rules.js
@@ -288,6 +288,11 @@ const $kurlc_rules = [
         redirect: 'url'
     },
     {
+        name: 'lenovo.com',
+        match: /.*.lenovo.com/i,
+        rules: ['PID', 'clickid', 'irgwc', 'cid', 'acid', 'linkTrack']
+    },
+    {
         name: 'itch.io',
         match: /itch.io/i,
         rules: ['fbclid']


### PR DESCRIPTION
Add 'PID', 'clickid', 'irgwc', 'cid', 'acid', 'linkTrack' rules for www.lenovo.com and support.lenovo.com websites

Tested with these URLs:
- https://www.lenovo.com/us/en/p/accessories-and-software/wireless-and-networking/wireless-&-networking_range-extenders/78024125?clickid=QOh3r01O5xyNTXZXv1RnE37sUkDXuW2vHUbKxg0&irgwc=1&PID=123412&acid=ww%3Aaffiliate%3Abv0as6&cid=us%3Aaffiliate%3Acxsaam
- https://support.lenovo.com/partslookup?linkTrack=PartSales_Footer

Fix https://github.com/DrKain/tidy-url/issues/29