### PR TITLE
Split cleaning logic into functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,7 +165,7 @@ export class TidyCleaner {
         }
     }
 
-    private handleAmpRedirectsAndDetermineReturn(url: string, data: IData) {
+    private handleAmpRedirectsAndDetermineReturn(url: string, data: IData): boolean {
         let needToReturnImmediately = false;
 
         const hasAmpRule = data.info.match.find((item) => item.amp);
@@ -196,8 +196,8 @@ export class TidyCleaner {
         }
     }
 
-    private rebuildUrl(original: URL, pathname: string): string {
-        return original.protocol + '//' + original.host + pathname + original.search + original.hash;
+    private rebuildUrl(original: URL, pathname: string, data: IData) {
+        data.url = original.protocol + '//' + original.host + pathname + original.search + original.hash;
     }
 
     private redirectIfNeeded(cleaner_ci: URLSearchParams, allow_reclean: boolean, original: URL, data: IData) {
@@ -363,7 +363,7 @@ export class TidyCleaner {
         this.updatePathNames(pathname, data);
 
         // Rebuild URL
-        data.url = this.rebuildUrl(original, pathname);
+        this.rebuildUrl(original, pathname, data);
 
         // Redirect if the redirect parameter exists
         this.redirectIfNeeded(cleaner_ci, allow_reclean, original, data);

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,8 @@ export class TidyCleaner {
                 data.info.match.push(rule);
             }
         }
+
+        return to_remove;
     }
 
     private handleAmpRedirectsAndDetermineReturn(url: string, data: IData): boolean {
@@ -334,7 +336,7 @@ export class TidyCleaner {
         cleaner.forEach((v, k) => cleaner_ci.append(k.toLowerCase(), v));
 
         // Loop through the rules and match them to the host name
-        this.fetchMatchingRules(original, to_remove, data);
+        to_remove = this.fetchMatchingRules(original, to_remove, data);
 
         // Stop cleaning if any exclude rule matches
         let ex_pass = true;


### PR DESCRIPTION
Created this PR based on the discussion in #101.

For reference, here are the mappings from the code comments to the 10 items mentioned in the issue. I split into functions the code I found under these comments.
1. Fetching matching rules - Loop through the rules and match them to the host name
2. Handle AMP redirects - Check if the match has any amp rules, if not we can redirect
3. Delete parameters - Delete any matching parameters
4. Updating path names - Update the pathname if needed
5. Rebuild URL
6. Redirecting based on parameter - Redirect if the redirect parameter exists
7. Decode handler
8. Empty hashes - Handle empty hash / anchors
9. Removing empty values - Remove empty values when requested
10. Checking reduction/difference - Reset the original URL if there is no change, just to be safe;