### PR TITLE
Upgrade AMP support

### DIFF
--- a/data/rules.js
+++ b/data/rules.js
@@ -149,7 +149,9 @@ const $kurlc_rules = [
             'ei', 'oq', 'gs_lcp', 'sclient', 'bih', 'biw', 'sa', 'dpr', 'rlz',
             'gs_lp', 'sca_esv', 'si', 'gs_l'
         ],
-        amp: /www\.google\.(?:.*)\/amp\/s\/(.*)/gim,
+        amp: {
+            regex: /www\.google\.(?:.*)\/amp\/s\/(.*)/gim,
+        },
         redirect: 'url'
     },
     {
@@ -256,10 +258,7 @@ const $kurlc_rules = [
             'upsellTrk', 'upsellTrackingId', 'src', 'trackingId',
             'midToken', 'midSig', 'trkEmail', 'eid'
         ],
-        allow: [
-            // One Time Password Token
-            'otpToken'
-        ]
+        allow: [ 'otpToken' ]
     },
     {
         name: 'indeed.com',
@@ -450,7 +449,9 @@ const $kurlc_rules = [
         name: 'ampproject.org',
         match: /cdn.ampproject.org/i,
         rules: ['amp_gsa', 'amp_js_v', 'usqp', 'outputType'],
-        amp: /cdn\.ampproject\.org\/v\/s\/(.*)\#(aoh|csi|referrer|amp)/gim
+        amp: {
+            regex: /cdn\.ampproject\.org\/v\/s\/(.*)\#(aoh|csi|referrer|amp)/gim
+        }
     },
     {
         name: 'nbcnews.com',
@@ -535,7 +536,9 @@ const $kurlc_rules = [
     {
         name: 'anrdoezrs.net',
         match: /anrdoezrs.net/i,
-        amp: /(?:.*)\/links\/(?:.*)\/type\/dlg\/sid\/\[subid_value\]\/(.*)/gi
+        amp: {
+            regex: /(?:.*)\/links\/(?:.*)\/type\/dlg\/sid\/\[subid_value\]\/(.*)/gi
+        }
     },
     {
         name: 'emjcd.com',
@@ -558,7 +561,7 @@ const $kurlc_rules = [
     {
         name: 'tvguide.com',
         match: /^www.tvguide.com/i,
-        amp: /(.*)\#link=/i
+        amp: { regex: /(.*)\#link=/i }
     },
     {
         name: 'ranker.com',
@@ -627,7 +630,7 @@ const $kurlc_rules = [
     {
         name: 'awstrack.me',
         match: /^.*awstrack.me/i,
-        amp: /awstrack.me\/L0\/(.*)/
+        amp: { regex: /awstrack.me\/L0\/(.*)/ }
     },
     {
         name: 'express.co.uk',
@@ -721,7 +724,12 @@ const $kurlc_rules = [
     {
         name: 'amp.scmp.com',
         match: /amp\.scmp\.com/i,
-        amp: /amp\.(.*)/i
+        amp: {
+            replace: {
+                text: 'amp.scmp.com',
+                with: 'scmp.com'
+            }
+        }
     },
     {
         name: 'justwatch.com',
@@ -876,7 +884,12 @@ const $kurlc_rules = [
     {
         name: 'amp.dw.com',
         match: /amp.dw.com/i,
-        amp: /amp\.(.*)/i
+        amp: {
+            replace: {
+                text: 'amp.dw.com',
+                with: 'dw.com'
+            }
+        }
     },
     {
         name: 'joybuggy.com',
@@ -912,7 +925,12 @@ const $kurlc_rules = [
     {
         name: 'knowyourmeme.com',
         match: /amp.knowyourmeme.com/i,
-        amp: /(?:\/\/|^)amp\.(.*)$/gim
+        amp: {
+            replace: {
+                text: 'amp.knowyourmeme.com',
+                with: 'knowyourmeme.com'
+            }
+        }
     },
     {
         name: 'ojrq.net',
@@ -922,7 +940,7 @@ const $kurlc_rules = [
     {
         name: 'click.pstmrk.it',
         match: /click.pstmrk.it/i,
-        amp: /click\.pstmrk\.it\/(?:[a-zA-Z0-9]){1,2}\/(.*?)\//gim,
+        amp: { regex: /click\.pstmrk\.it\/(?:[a-zA-Z0-9]){1,2}\/(.*?)\//gim }
     },
     {
         name: 'track.roeye.co.nz',
@@ -938,7 +956,12 @@ const $kurlc_rules = [
         name: 'cbsnews.com',
         match: /www.cbsnews.com/i,
         rules: ['ftag', 'intcid'],
-        replace: ['/amp']
+        amp: {
+            replace: {
+                text: 'cbsnews.com/amp/',
+                with: 'cbsnews.com/'
+            }
+        }
     },
     {
         name: 'jobs.venturebeat.com',
@@ -1165,13 +1188,28 @@ const $kurlc_rules = [
     {
         name: 'hypable.com',
         match: /www.hypable.com/i,
-        amp: /^(.*?)\/amp\//gi
+        amp: { replace: { text: /amp\/$/gi } }
     },
     {
         name: 'theguardian.com',
         match: /theguardian.com/i,
-        amp: /amp\.(.*)$/gi,
+        amp: {
+            replace: {
+                text: 'amp.theguardian.com',
+                with: 'theguardian.com'
+            }
+        },
         rules: ['INTCMP', 'acquisitionData', 'REFPVID']
+    },
+    {
+        name: 'indiatoday.in',
+        match: /www.indiatoday.in/i,
+        amp: {
+            replace: {
+                text: 'www.indiatoday.in/amp/',
+                with: 'www.indiatoday.in/'
+            }
+        }
     }
 ];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,21 +287,44 @@ export class TidyCleaner {
         if (this.config.allowAMP === false) {
             for (const rule of data.info.match) {
                 try {
-                    // Ensure the amp rule matches
-                    if (rule.amp && data.url.match(rule.amp)) {
-                        // Reset the lastIndex
-                        rule.amp.lastIndex = 0;
-                        const result = rule.amp.exec(data.url);
-                        if (result && result[1]) {
+                    // Ensure at least one rule exists
+                    if (rule.amp && (rule.amp.regex || rule.amp.replace)) {
+                        // Handle replacing text in the URL
+                        if (rule.amp.replace) {
+                            data.info.handler = rule.name;
+                            this.log('AMP Replace: ' + rule.amp.replace.text, 'info');
+                            const toReplace = rule.amp.replace.text;
+                            const toReplaceWith = rule.amp.replace.with ?? '';
+                            data.url = data.url.replace(toReplace, toReplaceWith);
+                        }
+
+                        // Use RegEx capture groups
+                        if (rule.amp.regex && data.url.match(rule.amp.regex)) {
+                            data.info.handler = rule.name;
+                            this.log('AMP RegEx: ' + rule.amp.regex, 'info');
+
+                            rule.amp.regex.lastIndex = 0;
+                            const result = rule.amp.regex.exec(data.url);
+
                             // If there is a result, replace the URL
-                            let target = decodeURIComponent(result[1]);
-                            if (!target.startsWith('https')) target = 'https://' + target;
-                            if (validateURL(target)) {
-                                data.url = allowReclean ? this.clean(target, false).url : target;
-                                if (data.url.endsWith('%3Famp')) data.url = data.url.slice(0, -6);
-                                if (data.url.endsWith('amp/')) data.url = data.url.slice(0, -4);
+                            if (result && result[1]) {
+                                let target = decodeURIComponent(result[1]);
+                                // Add the protocol when it's missing
+                                if (!target.startsWith('https')) target = 'https://' + target;
+                                // Valiate the URL to make sure it's still good
+                                if (validateURL(target)) {
+                                    // Sometimes the result is another domain that has its own tracking parameters
+                                    // So a re-clean can be useful.
+                                    data.url = allowReclean ? this.clean(target, false).url : target;
+                                }
+                            } else {
+                                this.log('AMP RegEx failed to get a result for ' + rule.name, 'error');
                             }
                         }
+
+                        // Remove trailing amp/ or /amp
+                        if (data.url.endsWith('%3Famp')) data.url = data.url.slice(0, -6);
+                        if (data.url.endsWith('amp/')) data.url = data.url.slice(0, -4);
                     }
                 } catch (error) {
                     this.log(`${error}`, 'error');

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -22,7 +22,20 @@ export interface IRule {
      * too many to fit in this description.
      * See this link for more info: https://redd.it/ehrq3z
      */
-    amp: RegExp | null;
+    amp: {
+        /**
+         * Standard AMP handling using RegExp capture groups.
+         */
+        regex?: RegExp | null;
+        /**
+         * Replace text in the URL. If `with` is used the text will be
+         * replaced with what you set instead of removing it.
+         */
+        replace?: {
+            text: string | RegExp;
+            with?: string;
+        };
+    };
     /**
      * @experimental
      * Used to decode a parameter or path, then redirect based on the returned object

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -26,25 +26,33 @@ export interface IRule {
         /**
          * Standard AMP handling using RegExp capture groups.
          */
-        regex?: RegExp | null;
+        regex?: RegExp;
         /**
          * Replace text in the URL. If `with` is used the text will be
          * replaced with what you set instead of removing it.
          */
         replace?: {
+            /** The text or RegEx you want to replace */
             text: string | RegExp;
+            /** The text you want to replace it with. Optional */
             with?: string;
+            /** Currently has no effect, this will change in another update */
+            target?: 'host' | 'full';
         };
     };
     /**
-     * @experimental
      * Used to decode a parameter or path, then redirect based on the returned object
      */
     decode: {
+        /** Target parameter */
         param?: string;
+        /** If the decoded response is JSON, this will look for a certain key */
         lookFor?: string;
+        /** Decide what encoding to use */
         encoding?: EEncoding;
+        /** Target the full path instead of a parameter */
         targetPath?: boolean;
+        /** Use a custom handler found in handlers.ts */
         handler?: string;
     };
     /** Remove empty values */
@@ -54,6 +62,7 @@ export interface IRule {
 export interface IData {
     /** Cleaned URL */
     url: string;
+    /** Some debugging information about what was changed */
     info: {
         /** Original URL before cleaning */
         original: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { IData, ILinkDiff } from './interface';
+import { ILinkDiff } from './interface';
 
 /**
  * Accepts any base64 string and attempts to decode it.


### PR DESCRIPTION
There's 13 rules using AMP rules at the moment, I will merge when they're all validated as not broken. This is also the first step for adding better AMP support to these URLs by giving the rules more options to work with.

One more added benefit of the new AMP control makes it easy to expand for edge cases. I'll be updating the documentation in the [wiki](https://github.com/DrKain/tidy-url/wiki) shortly.

- [x] google.com
- [x] ampproject.org
- [x] anrdoezrs.net
- [x] tvguide.com 
- [x] awstrack.me
- [x] amp.scmp.com (updated) 
- [x] amp.dw.com #83 
- [x] amp.knowyourmeme.com #92 
- [x] click.pstmrk.it #73 
- [x] cbsnews.com #94 
- [x] hypable.com 
- [x] theguardian.com 
- [x] indiatoday.in

